### PR TITLE
Replace magic English section strings with explicit :keyword pragma syntax

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -154,15 +154,15 @@ The trailing `%` becomes the short description (shown in the collapsed view), an
 
 ### Step 6: Add structured sections
 
-Use `##` headings in the help block to create recognized page sections. Each section type gets specialized rendering:
+Use `## :keyword` directives in the help block to create recognized page sections. Each directive type gets specialized rendering:
 
 ```matlab
-% ## Output Arguments
+% ## :outputs
 %
 % `y` — Rescaled data, returned as an array the same size as `x`
 % with values in the range $[a, b]$.
 %
-% ## Examples
+% ## :examples
 %
 % ### Rescale to default range [0, 1]
 %
@@ -178,19 +178,19 @@ Use `##` headings in the help block to create recognized page sections. Each sec
 % y = rescale(x, -1, 1)
 % ```
 %
-% ## Tips
+% ## :tips
 %
 % - For data with outliers, consider clipping before rescaling:
 %   `x = max(min(x, upper), lower)` before calling `rescale`.
 %
-% ## Algorithms
+% ## :algorithms
 %
 % The transformation applied is:
 %
 % $$y = a + \frac{x - \min(x)}{\max(x) - \min(x)} \cdot (b - a)$$
 ```
 
-`## Examples` with `###` subsections become separately titled examples. `## Algorithms` renders LaTeX math. `## Tips` renders as a styled bulleted list. The recognized section headings are: `Syntax`, `Input Arguments`, `Output Arguments`, `Examples`, `Tips`, `Algorithms`, `References`, `Version History`, and `More About`. Arbitrary section headings are also permitted; they just don't get special treatment. Manually specifying Syntax, Input Arguments, or Output Arguments in help comments overrides the automatically generated content.  
+`## :examples` with `###` subsections become separately titled examples. `## :algorithms` renders LaTeX math. `## :tips` renders as a styled bulleted list. The recognized directives are: `:syntax`, `:inputs`, `:outputs`, `:examples`, `:tips`, `:algorithms`, `:references`, `:version-history`, and `:more-about`. Arbitrary `## Headings` (without the `:` prefix) are also permitted — they render with the author's exact heading text and get no special treatment. Using `:syntax`, `:inputs`, or `:outputs` overrides the automatically generated content.
 
 ![rescale v5 — structured sections](images/rescale_v5.png)
 
@@ -200,17 +200,17 @@ Use `##` headings in the help block to create recognized page sections. Each sec
 
 ### Step 7: Override auto-generation
 
-By default, the Syntax block and Input Arguments section are auto-generated from the `arguments` block. If you need full control, add `## Syntax` or `## Input Arguments` sections in the help block to override them:
+By default, the Syntax block and Input Arguments section are auto-generated from the `arguments` block. If you need full control, add `## :syntax` or `## :inputs` directives in the help block to override them:
 
 ```matlab
-% ## Syntax
+% ## :syntax
 %
 % `Y = rescale(X)` rescales the elements of `X` to the default range
 % [0, 1].
 %
 % `Y = rescale(X, A, B)` rescales to the range [`A`, `B`].
 %
-% ## Input Arguments
+% ## :inputs
 %
 % `x` — Input data array.
 % Input data, specified as a vector, matrix, or N-D array. All
@@ -223,7 +223,7 @@ By default, the Syntax block and Input Arguments section are auto-generated from
 % (maximum of `x` maps to `a`).
 ```
 
-When present, `## Syntax` replaces the auto-generated syntax block entirely, and `## Input Arguments` replaces the argument descriptions from the `arguments` block. This gives you full control over the exact calling forms and descriptions shown on the page. Manually specifying arguments uses the following syntax:
+When present, `## :syntax` replaces the auto-generated syntax block entirely, and `## :inputs` replaces the argument descriptions from the `arguments` block. This gives you full control over the exact calling forms and descriptions shown on the page. Manually specifying arguments uses the following syntax:
 ```matlab
 % `argname` — Short description.
 % Long description is contained in contiguous comment lines following the 
@@ -310,7 +310,7 @@ classdef Sensor_v3_help
 % most recent reading. Use the `read` method to update the stored
 % value and the `calibrate` method to apply a zero-offset correction.
 %
-% ## Examples
+% ## :examples
 %
 % ```matlab
 % s = Sensor("Thermocouple-01", "temperature", Units="C");
@@ -334,7 +334,7 @@ Method help follows the same conventions as standalone functions — synopsis, s
         % measurement units.
 ```
 
-All the formatting from the function walkthrough applies: Markdown inline code, fenced code blocks, `## Examples` sections, `See also` links, and so on.
+All the formatting from the function walkthrough applies: Markdown inline code, fenced code blocks, `## :examples` directives, `See also` links, and so on.
 
 > [Full source](SampleFiles/Sensor/Sensor_v3_help.m) · [Rendered HTML](https://michellehirsch.github.io/matlab_custom_doc_prototype/Sensor/Sensor_v3_help.html)
 
@@ -394,7 +394,7 @@ The property table renders with group headings, making it easy to scan large cla
 
 ### Step 6: Override with structured sections
 
-Just as functions support `## Syntax` and `## Input Arguments` overrides, classes support a `## Properties` section in the class help block. This replaces the auto-generated property descriptions with manually authored content using the same keyed format as `## Input Arguments`:
+Just as functions support `## :syntax` and `## :inputs` overrides, classes support a `## :properties` directive in the class help block. This replaces the auto-generated property descriptions with manually authored content using the same keyed format as `## :inputs`:
 
 ```matlab
 classdef Sensor_v5_sections
@@ -402,7 +402,7 @@ classdef Sensor_v5_sections
 %
 % ...
 %
-% ## Properties
+% ## :properties
 %
 % `Name` — Sensor display name
 % Display name of the sensor, such as `"Thermocouple-01"`.
@@ -417,7 +417,7 @@ classdef Sensor_v5_sections
 % reflects the raw reading adjusted by the calibration `Offset`.
 ```
 
-When present, `## Properties` replaces the property descriptions from the `properties` block, giving you full control over the property documentation. Individual methods also support `## Syntax`, `## Input Arguments`, and `## Output Arguments` overrides, just like standalone functions.
+When present, `## :properties` replaces the property descriptions from the `properties` block, giving you full control over the property documentation. Individual methods also support `## :syntax`, `## :inputs`, and `## :outputs` overrides, just like standalone functions.
 
 > [Full source](SampleFiles/Sensor/Sensor_v5_sections.m) · [Rendered HTML](https://michellehirsch.github.io/matlab_custom_doc_prototype/Sensor/Sensor_v5_sections.html)
 

--- a/SampleFiles/DataLogger/DataLogger.m
+++ b/SampleFiles/DataLogger/DataLogger.m
@@ -9,7 +9,7 @@ classdef DataLogger < handle
 % `DataLogger` is a handle class, so all methods modify the object
 % in place without needing to reassign the output.
 %
-% ## Properties
+% ## :properties
 %
 % `Name` — Display name for the logger. Used as a label in log file
 % headers and diagnostic messages. Default is `"Untitled"`.
@@ -34,7 +34,7 @@ classdef DataLogger < handle
 % `NumSamples` — Total number of samples logged since the last
 % `start`, including samples already flushed to disk. Read-only.
 %
-% ## Examples
+% ## :examples
 %
 % ### Basic in-memory logging
 %
@@ -70,7 +70,7 @@ classdef DataLogger < handle
 % dl.stop();
 % ```
 %
-% ## Tips
+% ## :tips
 %
 % - Set `BufferSize` based on available memory and desired flush
 %   frequency. Smaller buffers flush more often, reducing data loss
@@ -86,7 +86,7 @@ classdef DataLogger < handle
 % > growing beyond `BufferSize`. Set a log file for long-running
 % > acquisitions.
 %
-% ## Version History
+% ## :version-history
 %
 % **Introduced in v1.0**
 %
@@ -94,7 +94,7 @@ classdef DataLogger < handle
 %
 % **v1.2** — Added `BufferFull` event and auto-flush behavior.
 %
-% ## More About
+% ## :more-about
 %
 % - [Logging Best Practices](logging-best-practices.html)
 % - [Working with Timetables](matlab:doc('timetable'))
@@ -138,7 +138,7 @@ classdef DataLogger < handle
         % `dl = DataLogger(name, LogFile=f, SampleRate=r, BufferSize=n)`
         % sets optional configuration properties at construction.
         %
-        % ## Input Arguments
+        % ## :inputs
         %
         % `name` — Display name for the logger.
         %
@@ -205,7 +205,7 @@ classdef DataLogger < handle
         % flushed. Fires `DataLogged` after each sample and
         % `BufferFull` when the buffer reaches capacity.
         %
-        % ## Input Arguments
+        % ## :inputs
         %
         % `value` — Scalar numeric value to record.
             arguments
@@ -235,7 +235,7 @@ classdef DataLogger < handle
         % `tt = getData(dl)` returns the currently buffered data as a
         % timetable with columns `Time` and `Value`.
         %
-        % ## Output Arguments
+        % ## :outputs
         %
         % `tt` — Buffered data, returned as a `timetable`. The
         % `Time` variable contains `datetime` timestamps and `Value`
@@ -257,11 +257,11 @@ classdef DataLogger < handle
         % to the specified CSV file. Unlike the automatic flush
         % mechanism, `export` does not clear the buffer afterward.
         %
-        % ## Input Arguments
+        % ## :inputs
         %
         % `filename` — Output file path. Specify as a string.
         %
-        % ## Examples
+        % ## :examples
         %
         % ```matlab
         % dl = DataLogger("Experiment");

--- a/SampleFiles/DataLogger/readme.md
+++ b/SampleFiles/DataLogger/readme.md
@@ -7,17 +7,17 @@ A handle class that logs timestamped numeric data to memory and file. This is th
 | Feature | Where it appears |
 |---------|-----------------|
 | Class synopsis (first line) | `classdef` help block |
-| `## Properties` with long descriptions keyed by name | Class help block — `Name`, `LogFile`, `SampleRate`, `BufferSize`, `IsRunning`, `NumSamples` |
+| `## :properties` with long descriptions keyed by name | Class help block — `Name`, `LogFile`, `SampleRate`, `BufferSize`, `IsRunning`, `NumSamples` |
 | Property inline `%` descriptions | `properties` blocks |
 | Property groups with access control | `properties (SetAccess = private)`, `properties (Access = protected)` |
 | Handle class + inheritance | `classdef DataLogger < handle` |
 | Events with inline descriptions | `events` block — `DataLogged`, `BufferFull`, `LoggingStarted`, `LoggingStopped` |
-| Constructor with `## Input Arguments` and NV pairs | `DataLogger(name, LogFile=..., ...)` |
-| Method help with `## Input Arguments` | `log`, `export` |
-| Method help with `## Output Arguments` | `getData` |
-| Method help with `## Examples` | `export` |
+| Constructor with `## :inputs` and NV pairs | `DataLogger(name, LogFile=..., ...)` |
+| Method help with `## :inputs` | `log`, `export` |
+| Method help with `## :outputs` | `getData` |
+| Method help with `## :examples` | `export` |
 | `> [!WARNING]` callout | Class help block |
 | `> [!NOTE]` callout | `start` method help |
-| `## Version History` | Class help block |
-| `## More About` with cross-links | Class help block |
+| `## :version-history` | Class help block |
+| `## :more-about` with cross-links | Class help block |
 | `See also` | Class help block |

--- a/SampleFiles/Sensor/Sensor_v3_help.m
+++ b/SampleFiles/Sensor/Sensor_v3_help.m
@@ -5,7 +5,7 @@ classdef Sensor
 % most recent reading. Use the `read` method to update the stored
 % value and the `calibrate` method to apply a zero-offset correction.
 %
-% ## Examples
+% ## :examples
 %
 % ```matlab
 % s = Sensor("Thermocouple-01", "temperature", Units="C");

--- a/SampleFiles/Sensor/Sensor_v3_help_block.m
+++ b/SampleFiles/Sensor/Sensor_v3_help_block.m
@@ -6,7 +6,7 @@ A `Sensor` object stores metadata about a physical sensor and its
 most recent reading. Use the `read` method to update the stored
 value and the `calibrate` method to apply a zero-offset correction.
 
-## Examples
+## :examples
 
 ```matlab
 s = Sensor("Thermocouple-01", "temperature", Units="C");

--- a/SampleFiles/Sensor/Sensor_v4_propdoc.m
+++ b/SampleFiles/Sensor/Sensor_v4_propdoc.m
@@ -5,7 +5,7 @@ classdef Sensor
 % most recent reading. Use the `read` method to update the stored
 % value and the `calibrate` method to apply a zero-offset correction.
 %
-% ## Examples
+% ## :examples
 %
 % ```matlab
 % s = Sensor("Thermocouple-01", "temperature", Units="C");

--- a/SampleFiles/Sensor/Sensor_v4_propdoc_block.m
+++ b/SampleFiles/Sensor/Sensor_v4_propdoc_block.m
@@ -6,7 +6,7 @@ A `Sensor` object stores metadata about a physical sensor and its
 most recent reading. Use the `read` method to update the stored
 value and the `calibrate` method to apply a zero-offset correction.
 
-## Examples
+## :examples
 
 ```matlab
 s = Sensor("Thermocouple-01", "temperature", Units="C");

--- a/SampleFiles/Sensor/Sensor_v5_sections.m
+++ b/SampleFiles/Sensor/Sensor_v5_sections.m
@@ -5,7 +5,7 @@ classdef Sensor
 % most recent reading. Use the `read` method to update the stored
 % value and the `calibrate` method to apply a zero-offset correction.
 %
-% ## Properties
+% ## :properties
 %
 % `Name` — Sensor display name
 % Display name of the sensor, such as `"Thermocouple-01"`.
@@ -33,7 +33,7 @@ classdef Sensor
 % Calibration offset applied to raw readings. Set by the
 % `calibrate` method.
 %
-% ## Examples
+% ## :examples
 %
 % ### Create a sensor and take a reading
 %
@@ -74,7 +74,7 @@ classdef Sensor
         % `s = Sensor(name, type, Units=u)` also specifies the
         % measurement units.
         %
-        % ## Input Arguments
+        % ## :inputs
         %
         % `name` — Sensor name
         % Display name for the sensor. Specify as a string or
@@ -104,7 +104,7 @@ classdef Sensor
         % and records the timestamp. The stored value is adjusted by
         % the calibration `Offset`.
         %
-        % ## Input Arguments
+        % ## :inputs
         %
         % `value` — Raw sensor reading
         % Raw sensor reading. Specify as a scalar double. The
@@ -124,7 +124,7 @@ classdef Sensor
         % correction so that future readings align with the known
         % reference value.
         %
-        % ## Input Arguments
+        % ## :inputs
         %
         % `knownValue` — Known reference value
         % Reference value from a calibration standard. Specify

--- a/SampleFiles/Sensor/Sensor_v6_override.m
+++ b/SampleFiles/Sensor/Sensor_v6_override.m
@@ -5,7 +5,7 @@ classdef Sensor
 % most recent reading. Use the `read` method to update the stored
 % value and the `calibrate` method to apply a zero-offset correction.
 %
-% ## Properties
+% ## :properties
 %
 % `Name` — Sensor display name
 % Display name of the sensor, such as `"Thermocouple-01"`.
@@ -33,7 +33,7 @@ classdef Sensor
 % Calibration offset applied to raw readings. Set by the
 % `calibrate` method.
 %
-% ## Examples
+% ## :examples
 %
 % ### Create a sensor and take a reading
 %
@@ -71,13 +71,13 @@ classdef Sensor
         function obj = Sensor(name, type, opts)
         % Sensor  Create a `Sensor` object.
         %
-        % ## Syntax
+        % ## :syntax
         %
         % `s = Sensor(name, type)`
         %
         % `s = Sensor(name, type, Units=u)`
         %
-        % ## Input Arguments
+        % ## :inputs
         %
         % `name` — Sensor name
         % Display name for the sensor. Specify as a string or
@@ -107,7 +107,7 @@ classdef Sensor
         % and records the timestamp. The stored value is adjusted by
         % the calibration `Offset`.
         %
-        % ## Input Arguments
+        % ## :inputs
         %
         % `value` — Raw sensor reading
         % Raw sensor reading. Specify as a scalar double. The
@@ -127,7 +127,7 @@ classdef Sensor
         % correction so that future readings align with the known
         % reference value.
         %
-        % ## Input Arguments
+        % ## :inputs
         %
         % `knownValue` — Known reference value
         % Reference value from a calibration standard. Specify

--- a/SampleFiles/Sensor/legacy/Sensor_v2_inline.m
+++ b/SampleFiles/Sensor/legacy/Sensor_v2_inline.m
@@ -5,7 +5,7 @@ classdef Sensor
 % recent reading.  Use the read method to update the stored value and
 % the calibrate method to apply a zero-offset correction.
 %
-% ## Examples
+% ## :examples
 %   s = Sensor("Thermocouple", "temperature");
 %   s = s.read(23.5);
 %   disp(s.Value)

--- a/SampleFiles/Sensor/legacy/Sensor_v3_full.m
+++ b/SampleFiles/Sensor/legacy/Sensor_v3_full.m
@@ -5,7 +5,7 @@ classdef Sensor
 % most recent reading. Use the `read` method to update the stored
 % value and the `calibrate` method to apply a zero-offset correction.
 %
-% ## Properties
+% ## :properties
 %
 % `Name` — Sensor display name
 % Display name of the sensor, such as `"Thermocouple-01"`.
@@ -33,7 +33,7 @@ classdef Sensor
 % Calibration offset applied to raw readings. Set by
 % the `calibrate` method. Default is `0`.
 %
-% ## Examples
+% ## :examples
 %
 % ### Create a sensor and take a reading
 %
@@ -74,7 +74,7 @@ classdef Sensor
         % `s = Sensor(name, type, Units=u)` also specifies the
         % measurement units.
         %
-        % ## Input Arguments
+        % ## :inputs
         %
         % `name` — Display name for the sensor. Specify as a
         % string or character vector.
@@ -101,7 +101,7 @@ classdef Sensor
         % and records the timestamp. The stored value is adjusted by
         % the calibration `Offset`.
         %
-        % ## Input Arguments
+        % ## :inputs
         %
         % `value` — Raw sensor reading. Specify as a scalar double.
         % The calibration offset is added before storing.
@@ -121,7 +121,7 @@ classdef Sensor
         % reference value. The offset is calculated as
         % `knownValue - currentValue`.
         %
-        % ## Input Arguments
+        % ## :inputs
         %
         % `knownValue` — Reference value from a calibration
         % standard. Specify as a scalar double.

--- a/SampleFiles/Sensor/readme.md
+++ b/SampleFiles/Sensor/readme.md
@@ -13,8 +13,8 @@ Each step adds one concept, mirroring the [rescale](../rescale/) function progre
 | `Sensor_v2_plain.m` | Traditional `%` help block on `classdef` and each method | Standard help — inline descriptions merge into auto-generated tables |
 | `Sensor_v3_help.m` | Same help with Markdown: backticks, fenced code blocks | Opt-in to Markdown for richer rendering |
 | `Sensor_v4_propdoc.m` | Preceding `%` blocks before properties and method arguments | Long descriptions (recommended approach) |
-| `Sensor_v5_sections.m` | `## Properties`, `## Input Arguments`, `## Examples` with subsections | Structured sections for professional layout |
-| `Sensor_v6_override.m` | `## Syntax` on constructor, property groups | Overriding auto-generation for full control |
+| `Sensor_v5_sections.m` | `## :properties`, `## :inputs`, `## :examples` with subsections | Structured sections for professional layout |
+| `Sensor_v6_override.m` | `## :syntax` on constructor, property groups | Overriding auto-generation for full control |
 
 ### What the progression shows
 
@@ -23,7 +23,7 @@ Each step adds one concept, mirroring the [rescale](../rescale/) function progre
 - **v2 → v3**: Adding Markdown formatting (backticks, fenced code blocks) gets richer rendering for free.
 - **v3 → v4**: Adding preceding `%` blocks in `properties` and `arguments` blocks gives detailed descriptions — the recommended way to document properties and arguments.
 - **v4 → v5**: Adding `##` section headings creates structured page sections: property docs, argument docs, examples with subsections.
-- **v5 → v6**: Adding `## Syntax` and property groups overrides auto-generation when you need full control.
+- **v5 → v6**: Adding `## :syntax` and property groups overrides auto-generation when you need full control.
 
 ## Block-Comment Variants
 

--- a/SampleFiles/addgradient/addgradient_v3_full.m
+++ b/SampleFiles/addgradient/addgradient_v3_full.m
@@ -5,7 +5,7 @@ function p = addgradient(ax, opts)
 % polished visual effect. The gradient is drawn as an interpolated
 % patch behind all other plot objects.
 %
-% ## Input Arguments
+% ## :inputs
 %
 % `ax` — Target axes. If omitted, uses the current axes (`gca`).
 %
@@ -21,13 +21,13 @@ function p = addgradient(ax, opts)
 % `[0, 1]` where `0` is fully transparent and `1` is fully opaque.
 % Default is `1`.
 %
-% ## Output Arguments
+% ## :outputs
 %
 % `p` — Handle to the patch object used to draw the gradient,
 % returned as a `matlab.graphics.primitive.Patch`. Use this to further
 % customize the gradient appearance after creation.
 %
-% ## Examples
+% ## :examples
 %
 % ### Basic gray gradient
 %
@@ -50,7 +50,7 @@ function p = addgradient(ax, opts)
 %     FaceAlpha=0.3);
 % ```
 %
-% ## Tips
+% ## :tips
 %
 % - Add the gradient **after** setting final axis limits, since the
 %   gradient patch is not automatically redrawn when limits change.

--- a/SampleFiles/dempk (FSDA)/dempk_v1_full.m
+++ b/SampleFiles/dempk (FSDA)/dempk_v1_full.m
@@ -10,7 +10,7 @@ function out = dempk(Y, k, g, opts)
 % - If `0 < g < 1`, components with pairwise overlap above the threshold
 %   `g` ($\omega^*$) are merged (same algorithm as `overlapmap`)
 %
-% ## Syntax
+% ## :syntax
 %
 % `out = dempk(Y, k, g)` merges the `k` components found by `tkmeans`
 % into `g` groups using hierarchical clustering, or merges all component
@@ -21,7 +21,7 @@ function out = dempk(Y, k, g, opts)
 % `dempk(Y, 50, 3, Alpha=0.1, Plots="contourf")` trims 10% of the data
 % and displays filled contour plots.
 %
-% ## Input Arguments
+% ## :inputs
 %
 % `Y` — Input data. $n \times v$ matrix where rows are observations
 % and columns are variables. Missing values (`NaN`) and infinite values
@@ -70,7 +70,7 @@ function out = dempk(Y, k, g, opts)
 % `opts.Ysave` — When `true`, the input matrix `Y` is saved into the
 % output structure. Default is `false`.
 %
-% ## Output Arguments
+% ## :outputs
 %
 % `out` — Results structure with the following fields:
 %
@@ -82,7 +82,7 @@ function out = dempk(Y, k, g, opts)
 %   `TkmeansOut=true`.
 % - `Y` — Original data matrix. Present only when `Ysave=true`.
 %
-% ## Examples
+% ## :examples
 %
 % ### Hierarchical merging of simulated clusters
 %
@@ -140,7 +140,7 @@ function out = dempk(Y, k, g, opts)
 %     Linkage="weights", Plots="ellipse");
 % ```
 %
-% ## Algorithms
+% ## :algorithms
 %
 % The algorithm proceeds in two stages:
 %
@@ -160,7 +160,7 @@ function out = dempk(Y, k, g, opts)
 %   merged by selecting the pair with maximum overlap, continuing to
 %   adjacent components until no remaining pair exceeds $\omega^* = g$.
 %
-% ## References
+% ## :references
 %
 % Melnykov, V., Michael, S. (2020), Clustering Large Datasets by Merging
 % K-Means Solutions, _Journal of Classification_, Vol. 37, pp. 97-123.

--- a/SampleFiles/dempk (FSDA)/dempk_v2_argblock.m
+++ b/SampleFiles/dempk (FSDA)/dempk_v2_argblock.m
@@ -10,7 +10,7 @@ function out = dempk(Y, k, g, opts)
 % - If `0 < g < 1`, components with pairwise overlap above the threshold
 %   `g` ($\omega^*$) are merged (same algorithm as `overlapmap`)
 %
-% ## Syntax
+% ## :syntax
 %
 % `out = dempk(Y, k, g)` merges the `k` components found by `tkmeans`
 % into `g` groups using hierarchical clustering, or merges all component
@@ -21,7 +21,7 @@ function out = dempk(Y, k, g, opts)
 % `dempk(Y, 50, 3, Alpha=0.1, Plots="contourf")` trims 10% of the data
 % and displays filled contour plots.
 %
-% ## Output Arguments
+% ## :outputs
 %
 % `out` — Results structure with the following fields:
 %
@@ -33,7 +33,7 @@ function out = dempk(Y, k, g, opts)
 %   `TkmeansOut=true`.
 % - `Y` — Original data matrix. Present only when `Ysave=true`.
 %
-% ## Examples
+% ## :examples
 %
 % ### Hierarchical merging of simulated clusters
 %
@@ -91,7 +91,7 @@ function out = dempk(Y, k, g, opts)
 %     Linkage="weights", Plots="ellipse");
 % ```
 %
-% ## Algorithms
+% ## :algorithms
 %
 % The algorithm proceeds in two stages:
 %
@@ -111,7 +111,7 @@ function out = dempk(Y, k, g, opts)
 %   merged by selecting the pair with maximum overlap, continuing to
 %   adjacent components until no remaining pair exceeds $\omega^* = g$.
 %
-% ## References
+% ## :references
 %
 % Melnykov, V., Michael, S. (2020), Clustering Large Datasets by Merging
 % K-Means Solutions, _Journal of Classification_, Vol. 37, pp. 97-123.

--- a/SampleFiles/mean/mean_v1_argdoc.m
+++ b/SampleFiles/mean/mean_v1_argdoc.m
@@ -5,7 +5,7 @@ function M = mean(A, dim, opts)
 % dimension, with options for weighted averaging, output type control,
 % and missing-value handling.
 %
-% ## Syntax
+% ## :syntax
 %
 % `M = mean(A)` returns the mean along the first dimension whose size
 % does not equal 1.
@@ -16,7 +16,7 @@ function M = mean(A, dim, opts)
 %
 % `M = mean(A, dim, Weights=W)` computes a weighted mean.
 %
-% ## Output Arguments
+% ## :outputs
 %
 % `M` — Mean values, returned as a scalar, vector, matrix, or
 % multidimensional array.  The size of `M` is the same as `A` except
@@ -24,7 +24,7 @@ function M = mean(A, dim, opts)
 % a 3-by-4 matrix and `dim` is 1, then `M` is a 1-by-4 row vector of
 % column means.
 %
-% ## Examples
+% ## :examples
 %
 % ### Column means of a matrix
 %
@@ -56,7 +56,7 @@ function M = mean(A, dim, opts)
 % class(M)   % 'single'
 % ```
 %
-% ## Algorithms
+% ## :algorithms
 %
 % **Unweighted mean:**
 %
@@ -66,7 +66,7 @@ function M = mean(A, dim, opts)
 %
 % $$M_w = \frac{\sum_{i=1}^{N} w_i \, A_i}{\sum_{i=1}^{N} w_i}$$
 %
-% ## Tips
+% ## :tips
 %
 % - For integer input, the default output type is `double`.  Use
 %   `OutType="native"` to keep the result in the original integer type,

--- a/SampleFiles/rescale/legacy/rescale_v3_full.m
+++ b/SampleFiles/rescale/legacy/rescale_v3_full.m
@@ -5,7 +5,7 @@ function y = rescale(x, a, b)
 % range $[a, b]$. The minimum value of `x` maps to `a` and the maximum
 % maps to `b`. Values between are linearly interpolated.
 %
-% ## Input Arguments
+% ## :inputs
 %
 % `x` — Input data array.
 % Input data, specified as a vector, matrix, or N-D array. All
@@ -20,13 +20,13 @@ function y = rescale(x, a, b)
 % Upper bound of the target range. If `b < a`, the output is reversed
 % (maximum of `x` maps to `a`).
 %
-% ## Output Arguments
+% ## :outputs
 %
 % `y` — Rescaled data.
 % Rescaled data, returned as an array the same size as `x` with values
 % in the range $[a, b]$.
 %
-% ## Examples
+% ## :examples
 %
 % ### Rescale to default range [0, 1]
 %
@@ -52,7 +52,7 @@ function y = rescale(x, a, b)
 % end
 % ```
 %
-% ## Tips
+% ## :tips
 %
 % - For data with outliers, consider clipping before rescaling:
 %   `x = max(min(x, upper), lower)` before calling `rescale`.
@@ -60,7 +60,7 @@ function y = rescale(x, a, b)
 %   columns or use `normalize(x, 'range')` from Statistics and
 %   Machine Learning Toolbox.
 %
-% ## Algorithms
+% ## :algorithms
 %
 % The transformation applied is:
 %

--- a/SampleFiles/rescale/readme.md
+++ b/SampleFiles/rescale/readme.md
@@ -13,8 +13,8 @@ This is the progression used in [GettingStarted.md](../../GettingStarted.md). Ea
 | `rescale_v2_plain.m` | Traditional `%` help block (synopsis, prose, plain-text example, `See also`) | Standard help block — argument descriptions from inline `%` merge in |
 | `rescale_v3_help.m` | Same help with Markdown: backticks, fenced code block, `**bold**` | Opt-in to Markdown for richer rendering |
 | `rescale_v4_argdoc.m` | Preceding `%` blocks before arguments in `arguments` block | Long argument descriptions (recommended approach) |
-| `rescale_v5_sections.m` | `## Output Arguments`, `## Examples`, `## Tips`, `## Algorithms` (LaTeX math) | Structured sections |
-| `rescale_v6_override.m` | `## Syntax` and `## Input Arguments` sections in help block | Overriding auto-generation for full control |
+| `rescale_v5_sections.m` | `## :outputs`, `## :examples`, `## :tips`, `## :algorithms` (LaTeX math) | Structured sections |
+| `rescale_v6_override.m` | `## :syntax` and `## :inputs` sections in help block | Overriding auto-generation for full control |
 
 ### What the progression shows
 
@@ -23,7 +23,7 @@ This is the progression used in [GettingStarted.md](../../GettingStarted.md). Ea
 - **v2 → v3**: Adding Markdown formatting (backticks, fenced code blocks) gets richer rendering for free.
 - **v3 → v4**: Adding preceding `%` blocks in the `arguments` block gives detailed argument descriptions — the recommended way to document arguments.
 - **v4 → v5**: Adding `##` section headings creates structured page sections: examples, tips, algorithms with LaTeX math.
-- **v5 → v6**: Adding `## Syntax` or `## Input Arguments` sections overrides auto-generation when you need full control.
+- **v5 → v6**: Adding `## :syntax` or `## :inputs` sections overrides auto-generation when you need full control.
 
 ## Block-Comment Variants
 
@@ -43,4 +43,4 @@ These files predate the recommended progression and explore different combinatio
 |------|---------------------|
 | `rescale_v1_plain.m` | Classic MATLAB help style with `arguments` block but no inline descriptions |
 | `rescale_v2_args.m` | Same help as v1_plain + inline `%` + Markdown markup |
-| `rescale_v3_full.m` | Full `## Input/Output Arguments` sections, `## Examples`, `## Tips`, `## Algorithms`, LaTeX math |
+| `rescale_v3_full.m` | Full `## Input/Output Arguments` sections, `## :examples`, `## :tips`, `## :algorithms`, LaTeX math |

--- a/SampleFiles/rescale/rescale_v5_sections.m
+++ b/SampleFiles/rescale/rescale_v5_sections.m
@@ -11,12 +11,12 @@ function y = rescale(x, a, b)
 % the target range.  If omitted, `A` defaults to `0` and `B` defaults
 % to `1`.
 %
-% ## Output Arguments
+% ## :outputs
 %
 % `y` — Rescaled data, returned as an array the same size as `x`
 % with values in the range $[a, b]$.
 %
-% ## Examples
+% ## :examples
 %
 % ### Rescale to default range [0, 1]
 %
@@ -42,7 +42,7 @@ function y = rescale(x, a, b)
 % end
 % ```
 %
-% ## Tips
+% ## :tips
 %
 % - For data with outliers, consider clipping before rescaling:
 %   `x = max(min(x, upper), lower)` before calling `rescale`.
@@ -50,7 +50,7 @@ function y = rescale(x, a, b)
 %   columns or use `normalize(x, 'range')` from Statistics and
 %   Machine Learning Toolbox.
 %
-% ## Algorithms
+% ## :algorithms
 %
 % The transformation applied is:
 %

--- a/SampleFiles/rescale/rescale_v5_sections_block.m
+++ b/SampleFiles/rescale/rescale_v5_sections_block.m
@@ -12,12 +12,12 @@ minimum value of `X` maps to 0 and the maximum maps to 1.
 the target range.  If omitted, `A` defaults to `0` and `B` defaults
 to `1`.
 
-## Output Arguments
+## :outputs
 
 `y` — Rescaled data, returned as an array the same size as `x`
 with values in the range $[a, b]$.
 
-## Examples
+## :examples
 
 ### Rescale to default range [0, 1]
 
@@ -43,7 +43,7 @@ for k = 1:size(M, 2)
 end
 ```
 
-## Tips
+## :tips
 
 - For data with outliers, consider clipping before rescaling:
   `x = max(min(x, upper), lower)` before calling `rescale`.
@@ -51,7 +51,7 @@ end
   columns or use `normalize(x, 'range')` from Statistics and
   Machine Learning Toolbox.
 
-## Algorithms
+## :algorithms
 
 The transformation applied is:
 

--- a/SampleFiles/rescale/rescale_v6_override.m
+++ b/SampleFiles/rescale/rescale_v6_override.m
@@ -1,13 +1,13 @@
 function y = rescale(x, a, b)
 % rescale  Rescale data to a specified range.
 %
-% ## Syntax
+% ## :syntax
 % `Y = rescale(X)` rescales the elements of `X` to the default range
 % [0, 1].
 %
 % `Y = rescale(X, A, B)` rescales to the range [`A`, `B`].
 %
-% ## Input Arguments
+% ## :inputs
 %
 % `x` — Input data array.
 % Input data, specified as a vector, matrix, or N-D array. All
@@ -22,13 +22,13 @@ function y = rescale(x, a, b)
 % Upper bound of the target range. If `b < a`, the output is reversed
 % (maximum of `x` maps to `a`).
 %
-% ## Output Arguments
+% ## :outputs
 %
 % `y` — Rescaled data.
 % Rescaled data, returned as an array the same size as `x` with values
 % in the range $[a, b]$.
 %
-% ## Examples
+% ## :examples
 %
 % ### Rescale to default range [0, 1]
 %
@@ -54,7 +54,7 @@ function y = rescale(x, a, b)
 % end
 % ```
 %
-% ## Tips
+% ## :tips
 %
 % - For data with outliers, consider clipping before rescaling:
 %   `x = max(min(x, upper), lower)` before calling `rescale`.
@@ -62,7 +62,7 @@ function y = rescale(x, a, b)
 %   columns or use `normalize(x, 'range')` from Statistics and
 %   Machine Learning Toolbox.
 %
-% ## Algorithms
+% ## :algorithms
 %
 % The transformation applied is:
 %

--- a/SampleFiles/smoothts/readme.md
+++ b/SampleFiles/smoothts/readme.md
@@ -7,13 +7,13 @@ A time series smoother with multiple call forms and name-value options. This exa
 | File | Key features exercised |
 |------|----------------------|
 | `smoothts_v1_plain.m` | Traditional help documenting multiple call forms in prose. No `arguments` block. Positional API (`method`, `window` as positional args). Shows how conventional help handles a complex function. |
-| `smoothts_v3_full.m` | The full grammar: `## Syntax` override (multiple call forms), `## Input Arguments` with NV-pair long descriptions (enumerated options with defaults), `## Output Arguments`, multiple `## Examples`, `## Algorithms` (math-heavy with LaTeX), `## Tips` with `> [!NOTE]` callout, `## References`, `See also`. Redesigned API uses name-value pairs via `arguments` block. |
+| `smoothts_v3_full.m` | The full grammar: `## :syntax` override (multiple call forms), `## :inputs` with NV-pair long descriptions (enumerated options with defaults), `## :outputs`, multiple `## :examples`, `## :algorithms` (math-heavy with LaTeX), `## :tips` with `> [!NOTE]` callout, `## :references`, `See also`. Redesigned API uses name-value pairs via `arguments` block. |
 
 ## Block-Comment Variants
 
 | File | Line-comment counterpart | What it demonstrates |
 |------|--------------------------|---------------------|
-| `smoothts_v3_full_block.m` | `smoothts_v3_full.m` | Full grammar in block-comment form: `## Syntax`, `## Input/Output Arguments`, `## Examples`, `## Algorithms` (LaTeX), `## Tips`, `## References`, `See also` — all as bare Markdown text. |
+| `smoothts_v3_full_block.m` | `smoothts_v3_full.m` | Full grammar in block-comment form: `## :syntax`, `## Input/Output Arguments`, `## :examples`, `## :algorithms` (LaTeX), `## :tips`, `## :references`, `See also` — all as bare Markdown text. |
 
 ## Design notes
 

--- a/SampleFiles/smoothts/smoothts_v3_full.m
+++ b/SampleFiles/smoothts/smoothts_v3_full.m
@@ -7,7 +7,7 @@ function y = smoothts(x, opts)
 %
 % If `x` is a matrix, each column is smoothed independently.
 %
-% ## Syntax
+% ## :syntax
 %
 % `y = smoothts(x)` smooths the time series `x` using a moving average
 % with the default window size.
@@ -19,7 +19,7 @@ function y = smoothts(x, opts)
 % `y = smoothts(x, Method="gaussian", Window=w, Sigma=s)` uses
 % Gaussian-weighted smoothing with explicit kernel width.
 %
-% ## Input Arguments
+% ## :inputs
 %
 % `x` — Input time series.
 % Input time series, specified as a numeric vector or matrix.
@@ -50,13 +50,13 @@ function y = smoothts(x, opts)
 % when `Method` is `"gaussian"`. Default is `Window/4`, which places
 % approximately 95% of the kernel weight within the window.
 %
-% ## Output Arguments
+% ## :outputs
 %
 % `y` — Smoothed time series.
 % Smoothed time series, returned as a numeric array the same
 % size as `x`.
 %
-% ## Examples
+% ## :examples
 %
 % ### Smooth a noisy sine wave
 %
@@ -88,7 +88,7 @@ function y = smoothts(x, opts)
 % plot(smoothed)
 % ```
 %
-% ## Algorithms
+% ## :algorithms
 %
 % **Moving average.** The output at index $i$ is:
 %
@@ -109,7 +109,7 @@ function y = smoothts(x, opts)
 %
 % where $Z$ is the normalizing constant ensuring $\sum g_k = 1$.
 %
-% ## Tips
+% ## :tips
 %
 % - Increasing `Window` produces smoother output but introduces more lag
 %   and reduces sensitivity to rapid changes.
@@ -123,7 +123,7 @@ function y = smoothts(x, opts)
 % > boundaries. This avoids padding artifacts but means the first
 % > and last few samples are smoothed with fewer points.
 %
-% ## References
+% ## :references
 %
 % 1. Hyndman, R.J. & Athanasopoulos, G. (2021). _Forecasting:
 %    Principles and Practice_, 3rd ed., OTexts.

--- a/SampleFiles/smoothts/smoothts_v3_full_block.m
+++ b/SampleFiles/smoothts/smoothts_v3_full_block.m
@@ -8,7 +8,7 @@ exponential smoothing, and Gaussian-weighted smoothing.
 
 If `x` is a matrix, each column is smoothed independently.
 
-## Syntax
+## :syntax
 
 `y = smoothts(x)` smooths the time series `x` using a moving average
 with the default window size.
@@ -20,7 +20,7 @@ with the default window size.
 `y = smoothts(x, Method="gaussian", Window=w, Sigma=s)` uses
 Gaussian-weighted smoothing with explicit kernel width.
 
-## Input Arguments
+## :inputs
 
 `x` — Input time series.
 Input time series, specified as a numeric vector or matrix.
@@ -51,13 +51,13 @@ Standard deviation of the Gaussian kernel, in samples. Only used
 when `Method` is `"gaussian"`. Default is `Window/4`, which places
 approximately 95% of the kernel weight within the window.
 
-## Output Arguments
+## :outputs
 
 `y` — Smoothed time series.
 Smoothed time series, returned as a numeric array the same
 size as `x`.
 
-## Examples
+## :examples
 
 ### Smooth a noisy sine wave
 
@@ -89,7 +89,7 @@ smoothed = smoothts(data, Window=11);
 plot(smoothed)
 ```
 
-## Algorithms
+## :algorithms
 
 **Moving average.** The output at index $i$ is:
 
@@ -110,7 +110,7 @@ $$g_k = \frac{1}{Z} \exp\!\left(-\frac{k^2}{2\sigma^2}\right)$$
 
 where $Z$ is the normalizing constant ensuring $\sum g_k = 1$.
 
-## Tips
+## :tips
 
 - Increasing `Window` produces smoother output but introduces more lag
   and reduces sensitivity to rapid changes.
@@ -124,7 +124,7 @@ where $Z$ is the normalizing constant ensuring $\sum g_k = 1$.
 > boundaries. This avoids padding artifacts but means the first
 > and last few samples are smoothed with fewer points.
 
-## References
+## :references
 
 1. Hyndman, R.J. & Athanasopoulos, G. (2021). _Forecasting:
    Principles and Practice_, 3rd ed., OTexts.

--- a/SampleFiles/smoothts/smoothts_v4_argdoc.m
+++ b/SampleFiles/smoothts/smoothts_v4_argdoc.m
@@ -7,7 +7,7 @@ function y = smoothts(x, opts)
 %
 % If `x` is a matrix, each column is smoothed independently.
 %
-% ## Syntax
+% ## :syntax
 %
 % `y = smoothts(x)` smooths the time series `x` using a moving average
 % with the default window size.
@@ -19,12 +19,12 @@ function y = smoothts(x, opts)
 % `y = smoothts(x, Method="gaussian", Window=w, Sigma=s)` uses
 % Gaussian-weighted smoothing with explicit kernel width.
 %
-% ## Output Arguments
+% ## :outputs
 %
 % `y` — Smoothed time series, returned as a numeric array the same
 % size as `x`.
 %
-% ## Examples
+% ## :examples
 %
 % ### Smooth a noisy sine wave
 %
@@ -56,7 +56,7 @@ function y = smoothts(x, opts)
 % plot(smoothed)
 % ```
 %
-% ## Algorithms
+% ## :algorithms
 %
 % **Moving average.** The output at index $i$ is:
 %
@@ -77,7 +77,7 @@ function y = smoothts(x, opts)
 %
 % where $Z$ is the normalizing constant ensuring $\sum g_k = 1$.
 %
-% ## Tips
+% ## :tips
 %
 % - Increasing `Window` produces smoother output but introduces more lag
 %   and reduces sensitivity to rapid changes.
@@ -91,7 +91,7 @@ function y = smoothts(x, opts)
 % > boundaries. This avoids padding artifacts but means the first
 % > and last few samples are smoothed with fewer points.
 %
-% ## References
+% ## :references
 %
 % 1. Hyndman, R.J. & Athanasopoulos, G. (2021). _Forecasting:
 %    Principles and Practice_, 3rd ed., OTexts.

--- a/SampleFiles/weightedmean/readme.md
+++ b/SampleFiles/weightedmean/readme.md
@@ -22,5 +22,5 @@ This example demonstrates six levels of documentation for the same function. The
 | `v1_args` | Inline argument comments | Trailing `%` on each arguments line |
 | `v2_help` | Traditional help block | H1 line, description, prose argument descriptions, indented example, See also |
 | `v3_markup` | Markdown formatting | Backtick code, **bold**, fenced code block — same content, richer rendering |
-| `v4_sections` | Custom sections | `## Examples` (two subsections) and `## Tips` |
-| `v5_override` | Section override | `## Syntax` overrides the auto-generated syntax block |
+| `v4_sections` | Custom sections | `## :examples` (two subsections) and `## :tips` |
+| `v5_override` | Section override | `## :syntax` overrides the auto-generated syntax block |

--- a/SampleFiles/weightedmean/weightedmean_v4_sections.m
+++ b/SampleFiles/weightedmean/weightedmean_v4_sections.m
@@ -35,7 +35,7 @@ function [m, ci] = weightedmean(x, w, dim, opts)
 % `Confidence` sets the confidence level for the interval returned in
 % `CI`.  Must be between `0` and `1`.  Default is `0.95`.
 %
-% ## Examples
+% ## :examples
 %
 % ### Basic weighted mean
 %
@@ -52,7 +52,7 @@ function [m, ci] = weightedmean(x, w, dim, opts)
 % avg = weightedmean(speeds, Method="harmonic")   % 48 km/h
 % ```
 %
-% ## Tips
+% ## :tips
 %
 % - Use `Method="harmonic"` when averaging rates or ratios (e.g., speeds
 %   or prices per unit).

--- a/SampleFiles/weightedmean/weightedmean_v5_argdoc.m
+++ b/SampleFiles/weightedmean/weightedmean_v5_argdoc.m
@@ -13,7 +13,7 @@ function [m, ci] = weightedmean(x, w, dim, opts)
 % `[M, CI] = weightedmean(...)` also returns a confidence interval `CI`
 % based on the weighted standard deviation.
 %
-% ## Examples
+% ## :examples
 %
 % ### Basic weighted mean
 %
@@ -30,7 +30,7 @@ function [m, ci] = weightedmean(x, w, dim, opts)
 % avg = weightedmean(speeds, Method="harmonic")   % 48 km/h
 % ```
 %
-% ## Tips
+% ## :tips
 %
 % - Use `Method="harmonic"` when averaging rates or ratios (e.g., speeds
 %   or prices per unit).

--- a/SampleFiles/weightedmean/weightedmean_v5_override.m
+++ b/SampleFiles/weightedmean/weightedmean_v5_override.m
@@ -5,7 +5,7 @@ function [m, ci] = weightedmean(x, w, dim, opts)
 % along a specified dimension.  Supports arithmetic, harmonic, and
 % geometric means.
 %
-% ## Syntax
+% ## :syntax
 %
 % `m = weightedmean(x)` computes the arithmetic mean of the elements of
 % `x`, using uniform weights.
@@ -26,7 +26,7 @@ function [m, ci] = weightedmean(x, w, dim, opts)
 % `[m, ci] = weightedmean(___)` also returns a confidence interval `ci`
 % based on the weighted standard deviation.
 %
-% ## Examples
+% ## :examples
 %
 % ### Basic weighted mean
 %
@@ -43,7 +43,7 @@ function [m, ci] = weightedmean(x, w, dim, opts)
 % avg = weightedmean(speeds, Method="harmonic")   % 48 km/h
 % ```
 %
-% ## Tips
+% ## :tips
 %
 % - Use `Method="harmonic"` when averaging rates or ratios (e.g., speeds
 %   or prices per unit).

--- a/SampleFiles/weightedmean/weightedmean_v6_helpsections.m
+++ b/SampleFiles/weightedmean/weightedmean_v6_helpsections.m
@@ -13,7 +13,7 @@ function [m, ci] = weightedmean(x, w, dim, opts)
 % `[M, CI] = weightedmean(...)` also returns a confidence interval `CI`
 % based on the weighted standard deviation.
 %
-% ## Input Arguments
+% ## :inputs
 %
 % `x` — Input data.
 % Input data, specified as a vector, matrix, or N-D array.
@@ -44,7 +44,7 @@ function [m, ci] = weightedmean(x, w, dim, opts)
 % Confidence level for the interval returned in the second output
 % `CI`.  Must be between 0 and 1.
 %
-% ## Output Arguments
+% ## :outputs
 %
 % `m` — Weighted mean.
 % Weighted mean, returned as a scalar, vector, or array depending
@@ -55,7 +55,7 @@ function [m, ci] = weightedmean(x, w, dim, opts)
 % returned as an array with two slices along dimension `dim`
 % (lower bound and upper bound).
 %
-% ## Examples
+% ## :examples
 %
 % ### Basic weighted mean
 %
@@ -72,7 +72,7 @@ function [m, ci] = weightedmean(x, w, dim, opts)
 % avg = weightedmean(speeds, Method="harmonic")   % 48 km/h
 % ```
 %
-% ## Tips
+% ## :tips
 %
 % - Use `Method="harmonic"` when averaging rates or ratios (e.g., speeds
 %   or prices per unit).

--- a/class-support-design.md
+++ b/class-support-design.md
@@ -35,9 +35,9 @@ The help comment after `classdef` works exactly like a function help comment: fi
 
 ### 2. Creation Section ← Constructor Help
 
-The constructor is a method whose help comment has calling-form paragraphs, description, and `## Input Arguments` — exactly like a function page. We automatically pull this into the class page's "Creation" section.
+The constructor is a method whose help comment has calling-form paragraphs, description, and `## :inputs` — exactly like a function page. We automatically pull this into the class page's "Creation" section.
 
-**Why not a `## Creation` section in the class help?** It would duplicate the constructor's help and create a sync problem. The constructor IS the authoritative source for creation documentation.
+**Why not a `## :creation` directive in the class help?** It would duplicate the constructor's help and create a sync problem. The constructor IS the authoritative source for creation documentation.
 
 **Classes with no explicit constructor:** Auto-generate a minimal creation syntax: `obj = ClassName` or `obj = ClassName(Name=Value)` if the class has public settable properties. No description section. If the class has neither a constructor nor settable properties, omit the Creation section entirely.
 
@@ -61,11 +61,11 @@ The three-layer documentation model carries over directly:
 |---|---|---|
 | **Inline short** | Trailing `%` on property line | Always (summary tables, tooltips) |
 | **Preceding block** | Multi-line `%` before property line, inside `properties` block | Moderate detail (1–5 lines) |
-| **`## Properties` section** | In class help comment | Extensive (multi-paragraph, math, images) |
+| **`## :properties` directive** | In class help comment | Extensive (multi-paragraph, math, images) |
 
-Override rule: **"Section wins entirely"** — same as arguments. If a `## Properties` section exists in the class help, inline/preceding comments are ignored for ALL properties.
+Override rule: **"Section wins entirely"** — same as arguments. If a `## :properties` directive exists in the class help, inline/preceding comments are ignored for ALL properties.
 
-**Recommendation: Use inline comments as the default.** Only graduate to `## Properties` if you genuinely need multi-paragraph descriptions for properties. Most classes won't.
+**Recommendation: Use inline comments as the default.** Only graduate to `## :properties` if you genuinely need multi-paragraph descriptions for properties. Most classes won't.
 
 **Rationale for keeping "section wins entirely":** Consistency with the argument model. Two different override models would be confusing. The inline approach is compact enough that even classes with 30+ properties stay manageable.
 
@@ -96,7 +96,7 @@ Rules:
 
 **Tradeoff:** This requires splitting a single `properties` block into multiple blocks to get groups. This is a minor code structure change, but arguably better code organization, and entirely optional. Users who don't want groups don't split.
 
-**Alternative considered:** `### Group Name` subheadings inside a `## Properties` section. Rejected because it requires the verbose `## Properties` approach and disconnects group structure from code.
+**Alternative considered:** `### Group Name` subheadings inside a `## :properties` section. Rejected because it requires the verbose `## :properties` approach and disconnects group structure from code.
 
 ### 5. Property Visibility from Block Attributes
 
@@ -137,7 +137,7 @@ function obj = read(obj, value)
 %
 % `s = read(s, value)` stores `value` as the current reading.
 %
-% ## Input Arguments
+% ## :inputs
 %
 % `s` — Input `Sensor` object.
 %
@@ -233,10 +233,10 @@ Concern: will classdef files get gigantic with comments?
 
 **Estimate for a moderate class** (8 methods, 10 properties, like DataLogger):
 
-| Component | Lines (inline property docs) | Lines (## Properties section) |
+| Component | Lines (inline property docs) | Lines (## :properties section) |
 |---|---|---|
 | Class help (description, examples, tips, see also) | ~40 | ~40 |
-| `## Properties` section in class help | 0 | ~50 |
+| `## :properties` section in class help | 0 | ~50 |
 | Properties blocks (with inline comments) | ~15 | ~12 |
 | Constructor help | ~25 | ~25 |
 | Other method helps (7 × ~15) | ~105 | ~105 |
@@ -245,10 +245,10 @@ Concern: will classdef files get gigantic with comments?
 
 **For a large class** (20 methods, 30 properties):
 
-| Component | Lines (inline) | Lines (## Properties) |
+| Component | Lines (inline) | Lines (## :properties) |
 |---|---|---|
 | Class help | ~50 | ~50 |
-| `## Properties` section | 0 | ~150 |
+| `## :properties` section | 0 | ~150 |
 | Properties blocks | ~45 | ~35 |
 | Constructor help | ~30 | ~30 |
 | Method helps (19 × ~15) | ~285 | ~285 |
@@ -272,7 +272,7 @@ MATLAB class files of 800–1000 lines are normal for well-factored classes. The
 - Help comment grammar (Markdown, `##` sections, `See also`)
 - Argument documentation (three-layer model) — applies to constructor and methods
 - Syntax block generation (three-priority model) — applies to constructor and methods
-- Section headings (`## Examples`, `## Tips`, `## Algorithms`, etc.)
+- Section directives (`## :examples`, `## :tips`, `## :algorithms`, etc.)
 - Rendering: Markdown, code blocks, callouts, math, cross-references
 
 ## What's New for Classes

--- a/doc-framework-spec.md
+++ b/doc-framework-spec.md
@@ -1,6 +1,6 @@
 # MATLAB Custom Documentation Framework — Functional Specification
 
-*Draft: 2026-02-10*
+*Draft: 2026-02-23*
 
 ---
 
@@ -37,7 +37,7 @@ This principle drives a deliberate split between what the framework generates au
 
 2. **If the author must add information, keep it close to the code.** Argument descriptions go as inline or preceding comments right next to the argument declaration in the `arguments` block. Property descriptions go next to the property declaration. This proximity makes the documentation easy to find, easy to keep in sync, and hard to forget.
 
-3. **If there is no natural code location for the information, it goes in the help comment block.** Some documentation — the synopsis, examples, tips, algorithms — has no corresponding code construct. These live in the help comment block, organized by recognized `##` section headings.
+3. **If there is no natural code location for the information, it goes in the help comment block.** Some documentation — the synopsis, examples, tips, algorithms — has no corresponding code construct. These live in the help comment block, organized by recognized `## :keyword` section directives.
 
 ### What's Automatic vs. What's Manual
 
@@ -45,18 +45,18 @@ This principle drives a deliberate split between what the framework generates au
 |---|---|---|---|
 | **Title** | Function/class name | — | — |
 | **Synopsis** | — | One-line description | First line of help comment |
-| **Syntax block** | Generated from `metafunction` / `arguments` block (calling forms only, no descriptions) | Calling forms + descriptions | Calling-form paragraphs in description text, or `## Syntax` section |
+| **Syntax block** | Generated from `metafunction` / `arguments` block (calling forms only, no descriptions) | Calling forms + descriptions | Calling-form paragraphs in description text, or `## :syntax` directive |
 | **Description** | — | Free-form prose, optionally with calling-form paragraphs | Help comment body (before any `##` heading) |
 | **Input arguments: name, type, size, default** | Extracted from `arguments` block | — | — |
-| **Input arguments: descriptions** | — | Short and/or long descriptions | Inline/preceding comments in `arguments` block, or `## Input Arguments` section |
+| **Input arguments: descriptions** | — | Short and/or long descriptions | Inline/preceding comments in `arguments` block, or `## :inputs` section |
 | **Output arguments: name, type, size** | Extracted from `arguments (Output)` block if present | — | — |
-| **Output arguments: descriptions** | — | Short and/or long descriptions | Comments in `arguments (Output)` block, or `## Output Arguments` section |
+| **Output arguments: descriptions** | — | Short and/or long descriptions | Comments in `arguments (Output)` block, or `## :outputs` section |
 | **Name-value arguments** | Name, type, size, default from `arguments` block | Descriptions | Same as input arguments |
-| **Properties** | Name, type, size, default from `properties` block | Descriptions | Inline/preceding comments in `properties` block, or `## Properties` section |
+| **Properties** | Name, type, size, default from `properties` block | Descriptions | Inline/preceding comments in `properties` block, or `## :properties` section |
 | **See also** | — | Related function names | `See also` line in help comment |
-| **Examples** | — | Code examples with narrative | `## Examples` section |
-| **Tips, Algorithms, References, etc.** | — | Prose content | Corresponding `##` sections |
-| **Version History** | — | Release history entries | `## Version History` section |
+| **Examples** | — | Code examples with narrative | `## :examples` section |
+| **Tips, Algorithms, References, etc.** | — | Prose content | Corresponding `## :keyword` sections |
+| **Version History** | — | Release history entries | `## :version-history` section |
 | **Methods (class page)** | Method list auto-aggregated from class | Per-method documentation | Each method's own help comment |
 
 This table illustrates the progressive enhancement model: a bare function with an `arguments` block already produces a page with a title, a syntax block, and a fully structured argument table (names, types, defaults). Every row in the "Author provides" column is optional — the author adds only what they want, where they want it.
@@ -186,6 +186,73 @@ myFunc  Brief one-line description.
 
 ---
 
+## Pragma Syntax
+
+### Recognized Section Directives
+
+Some `##` headings in a help comment block are **recognized directives** that trigger special parsing and rendering behavior — they create named sections whose content the framework understands structurally (argument entries, syntax entries, example subsections, etc.) and whose rendered labels are supplied by the doc system rather than taken verbatim from the source.
+
+A recognized directive uses a **`:keyword` prefix** inside the `##` heading:
+
+```matlab
+% ## :inputs
+% ## :outputs
+% ## :syntax
+% ## :examples
+```
+
+The complete set of recognized directives:
+
+| Directive | Rendered section heading |
+|---|---|
+| `## :syntax` | Syntax |
+| `## :inputs` | Input Arguments |
+| `## :outputs` | Output Arguments |
+| `## :properties` | Properties |
+| `## :examples` | Examples |
+| `## :tips` | Tips |
+| `## :algorithms` | Algorithms |
+| `## :references` | References |
+| `## :version-history` | Version History |
+| `## :more-about` | More About |
+
+Any `##` heading **without** a `:` prefix is an author-defined section. It renders with the author's exact heading text and gets no special treatment:
+
+```matlab
+% ## Learn More        ← author section, renders verbatim
+% ## Background        ← author section, renders verbatim
+% ## :examples         ← recognized directive, renders as "Examples" with special layout
+```
+
+### Why Directives, Not Headings
+
+The original design used specific English strings as recognized headings (`## Input Arguments`, `## Examples`, etc.). This was rejected for three reasons:
+
+1. **Fragility** — section names must be typed exactly right. A typo like `## Input Arguements` or wrong case silently creates a custom section instead of triggering recognition. There is no way to tell from reading the source whether a heading is "special" or not.
+
+2. **Locale problem** — English-only source syntax is awkward for non-English authors and impossible to localize. With directives, the author writes `## :inputs` in any language context; the rendered heading ("Input Arguments", "Argumentos de entrada", etc.) is supplied by the doc system based on the user's locale.
+
+3. **Not extensible** — a vocabulary of magic English strings doesn't generalize to a broader directive system. The `:keyword` prefix is the extension point: future directives beyond section headings (block-level embeds, cross-references, includes) use the same `:` prefix convention, making the system consistent and learnable.
+
+### Extensibility: Block-Level Directives
+
+The `:keyword` prefix is designed to grow into a general directive vocabulary. Section directives always appear as `## :keyword` because they create headings. Future **block-level directives** — which produce content without a heading — will use `:directive` on its own line:
+
+```markdown
+:embed mypackage.myFunc
+:embed mypackage.myFunc#examples
+```
+
+This would allow a standalone Markdown page to pull in auto-generated reference content from source files, similar to mkdocstrings' `:::` syntax. Section directives and block-level directives use the same `:` prefix, making the mental model consistent: `:keyword` always means "instruction to the doc system."
+
+> **Rationale:** Alternatives considered before settling on `## :keyword`:
+>
+> - **Magic English strings** (`## Input Arguments`): original design. Fragile, locale-specific, and not extensible. Rejected.
+> - **Lowercase no-space** (`##inputs`): exploits CommonMark's requirement for a space after `#`, so `##inputs` is not a valid Markdown heading and is unambiguously a pragma. Clever, but relies on two simultaneous subtle signals (no space AND lowercase), neither of which is visually obvious when reading source. More importantly, this trick works only in Markdown heading context — it cannot generalize to block-level directives (`:embed`, etc.) that don't involve headings at all. Rejected.
+> - **Explicit `:` prefix** (`## :inputs`): selected. The `##` is standard Markdown (always creates a heading). The `:` prefix is the directive signal — unambiguous, visually distinct from prose headings, and consistent with directive syntax conventions in reStructuredText (`:param:`), CSS pseudo-selectors, and YAML. Extends naturally to a full directive vocabulary.
+
+---
+
 ## Auto-Generated Page Sections
 
 The renderer automatically generates the following page sections from file metadata and help comments. No explicit tagging is required.
@@ -200,11 +267,11 @@ From the first help comment line (see above).
 
 The compact syntax block at the top of the page and the Description section below it are tightly coupled, mirroring the structure of MathWorks doc pages: each calling form in the syntax block has a corresponding description paragraph. The framework supports three modes for populating these, applied in priority order:
 
-**Priority 1 — `## Syntax` section (explicit full control).**
-When the author includes a `## Syntax` section in the help comment block, it is the sole source for the syntax block and syntax-description pairs. Auto-generation does not run. See `## Syntax` under **Optional Enhancement Sections** below for the grammar.
+**Priority 1 — `## :syntax` directive (explicit full control).**
+When the author includes a `## :syntax` section in the help comment block, it is the sole source for the syntax block and syntax-description pairs. Auto-generation does not run. See `## :syntax` under **Optional Enhancement Sections** below for the grammar.
 
 **Priority 2 — Calling-form paragraphs in the description text.**
-If no `## Syntax` section exists, the renderer scans the freeform description (the help text before any `##` heading) for **calling-form paragraphs** — paragraphs whose first element is a backtick-wrapped expression containing the function name and `(`. These paragraphs serve double duty:
+If no `## :syntax` directive exists, the renderer scans the freeform description (the help text before any `## :keyword` directive) for **calling-form paragraphs** — paragraphs whose first element is a backtick-wrapped expression containing the function name and `(`. These paragraphs serve double duty:
 
 - The calling form (the backtick-wrapped portion) is extracted into the compact syntax block
 - The full paragraph renders as a syntax-description pair in the Description section
@@ -233,7 +300,7 @@ Any description paragraphs that are *not* calling-form paragraphs render as intr
 The renderer extracts five calling forms for the compact syntax block and renders five syntax-description pairs in the Description section.
 
 **Priority 3 — Auto-generation from `metafunction` (zero-effort fallback).**
-If neither a `## Syntax` section nor calling-form paragraphs exist, the renderer auto-generates the syntax block from function metadata. This is the zero-effort baseline: any function with an `arguments` block gets a useful syntax section with no authoring required.
+If neither a `## :syntax` directive nor calling-form paragraphs exist, the renderer auto-generates the syntax block from function metadata. This is the zero-effort baseline: any function with an `arguments` block gets a useful syntax section with no authoring required.
 
 Auto-generation uses `metafunction` (R2026a) to introspect `Signature.Inputs` and `Signature.Outputs`, then generates calling forms following these rules:
 
@@ -256,7 +323,7 @@ ___ = weightedmean(___, Name=Value)
 [m, ci] = weightedmean(___)
 ```
 
-Auto-generated forms have no descriptions — only the compact syntax block is rendered. To add descriptions, the author graduates to Priority 2 (calling-form paragraphs) or Priority 1 (`## Syntax`).
+Auto-generated forms have no descriptions — only the compact syntax block is rendered. To add descriptions, the author graduates to Priority 2 (calling-form paragraphs) or Priority 1 (`## :syntax`).
 
 **Legacy fallback** — if the function has no `arguments` block (`Signature.HasInputValidation` is false), or if `metafunction` is unavailable, the renderer strips the `function` keyword from the declaration line.
 
@@ -272,9 +339,9 @@ This creates an all-or-nothing gap between zero effort and full manual authoring
 |---|---|---|---|
 | **Do nothing** (Priority 3) | Auto-generated from `metafunction` — correct, complete | None — syntax block only, no per-syntax descriptions | Zero |
 | **Calling-form paragraphs** (Priority 2) | Extracted from author's backtick-wrapped forms | Author writes a paragraph per form | Must write every form + description manually |
-| **`## Syntax` section** (Priority 1) | From the section | Author writes a paragraph per form | Must write every form + description manually |
+| **`## :syntax` directive** (Priority 1) | From the section | Author writes a paragraph per form | Must write every form + description manually |
 
-There is no middle ground where the author gets the auto-generated forms *and* attaches descriptions to them. The moment the author writes any calling-form paragraph or `## Syntax` entry, auto-generation turns off entirely and the author owns the full set. This is by design — partial override of an auto-generated list would be confusing and fragile — but it means the step from "free syntax block" to "syntax block with descriptions" is a significant jump in authoring effort.
+There is no middle ground where the author gets the auto-generated forms *and* attaches descriptions to them. The moment the author writes any calling-form paragraph or `## :syntax` entry, auto-generation turns off entirely and the author owns the full set. This is by design — partial override of an auto-generated list would be confusing and fragile — but it means the step from "free syntax block" to "syntax block with descriptions" is a significant jump in authoring effort.
 
 **Why this gap exists and why it's acceptable:**
 
@@ -288,7 +355,7 @@ There is no middle ground where the author gets the auto-generated forms *and* a
 
 The gap between auto-generated syntaxes (no descriptions) and fully manual syntaxes (with descriptions) could be eased by editor tooling that helps the author graduate from Priority 3 to Priority 2 or Priority 1 without starting from a blank page. Several approaches could help:
 
-**1. "Populate Syntax" code action / quick fix.** The editor detects that a function has an `arguments` block but no calling-form paragraphs or `## Syntax` section. It offers a code action (lightbulb menu or right-click) that inserts a scaffolded set of calling-form paragraphs into the help comment, pre-filled with the same forms that auto-generation would produce. The author then edits these paragraphs to add descriptions. For `weightedmean`, this would insert:
+**1. "Populate Syntax" code action / quick fix.** The editor detects that a function has an `arguments` block but no calling-form paragraphs or `## :syntax` directive. It offers a code action (lightbulb menu or right-click) that inserts a scaffolded set of calling-form paragraphs into the help comment, pre-filled with the same forms that auto-generation would produce. The author then edits these paragraphs to add descriptions. For `weightedmean`, this would insert:
 
 ```matlab
 % weightedmean  Compute the weighted mean of an array.
@@ -306,10 +373,10 @@ The gap between auto-generated syntaxes (no descriptions) and fully manual synta
 
 Each calling-form paragraph is ready for the author to append a description after the backtick-wrapped form. This eliminates the tedious work of figuring out and typing each calling form — the author's only task is writing descriptions.
 
-**2. "Populate Syntax Section" variant.** Same idea, but inserts a `## Syntax` section instead of calling-form paragraphs in the description body. Useful for authors who prefer the `## Syntax` organizational style.
+**2. "Populate Syntax Section" variant.** Same idea, but inserts a `## :syntax` section instead of calling-form paragraphs in the description body. Useful for authors who prefer the explicit directive style.
 
-**3. Staleness detection / sync warnings.** When the author has calling-form paragraphs or a `## Syntax` section, the editor compares the documented forms against what `metafunction` would generate. If the `arguments` block has changed (e.g., a new optional argument was added), the editor warns that the documented syntaxes may be out of date. This could surface as:
-- A diagnostic/warning squiggle on the `## Syntax` heading or on calling-form paragraphs that don't match current metadata
+**3. Staleness detection / sync warnings.** When the author has calling-form paragraphs or a `## :syntax` directive, the editor compares the documented forms against what `metafunction` would generate. If the `arguments` block has changed (e.g., a new optional argument was added), the editor warns that the documented syntaxes may be out of date. This could surface as:
+- A diagnostic/warning squiggle on the `## :syntax` heading or on calling-form paragraphs that don't match current metadata
 - A quick fix to insert a new calling-form paragraph for the unmatched argument
 
 **4. Live preview pane.** A side panel shows the rendered doc page as the author edits. This helps the author see what the reader will see — particularly useful for verifying that calling-form paragraphs are being detected correctly and that the syntax block looks right.
@@ -322,12 +389,12 @@ Auto-generated from the `arguments` block for inputs. Each entry includes:
 - **Size/type constraints** — from the `arguments` block
 - **Default value** — from the `arguments` block
 - **Short description** — from the inline trailing comment on the argument line (see below)
-- **Long description** — from a matching entry in a `## Input Arguments` section in the help block, if present
+- **Long description** — from a matching entry in a `## :inputs` section in the help block, if present
 
 Name-value arguments (`opts.Name` style) are rendered in a separate **Name-Value Arguments** subsection, consistent with MATLAB doc conventions.
 
 ### Output Arguments
-Short descriptions come from an `## Output Arguments` section in the help block, keyed by argument name. If an `arguments` output block is present, size/type constraints are pulled from it automatically; otherwise the description stands alone. This symmetric design means input and output arguments are documented the same way, and output arguments never require an `arguments` block to be documented.
+Short descriptions come from a `## :outputs` section in the help block, keyed by argument name. If an `arguments` output block is present, size/type constraints are pulled from it automatically; otherwise the description stands alone. This symmetric design means input and output arguments are documented the same way, and output arguments never require an `arguments` block to be documented.
 
 ### See Also
 If the help block contains a line beginning with `See also` (case-insensitive), the referenced names are rendered as hyperlinks to their respective doc pages. This matches the existing MATLAB convention requiring no new syntax.
@@ -416,9 +483,9 @@ The long description should **repeat/incorporate the short description** so it r
 
 This approach works best when descriptions are short to moderate (1–5 lines per argument). For arguments with extensive documentation (bulleted option lists, multi-paragraph explanations, math), the help-block approach below may be cleaner, since it avoids interleaving prose with type/size/validator declarations.
 
-### Long-Form Descriptions in `## Input Arguments` / `## Output Arguments`
+### Long-Form Descriptions in `## :inputs` / `## :outputs`
 
-For input arguments requiring more explanation, a `## Input Arguments` section in the help comment block provides extended descriptions, keyed by argument name wrapped in backticks (matched case-sensitively). Output arguments are documented in a `## Output Arguments` section using the same pattern. In the rendered output, argument names are displayed in **bold monospace** — the renderer adds bold styling even though the source uses only backticks.
+For input arguments requiring more explanation, a `## :inputs` section in the help comment block provides extended descriptions, keyed by argument name wrapped in backticks (matched case-sensitively). Output arguments are documented in a `## :outputs` section using the same pattern. In the rendered output, argument names are displayed in **bold monospace** — the renderer adds bold styling even though the source uses only backticks.
 
 Each entry has a **structural short/long split**: the text on the same line as `` `argName` — `` is the short description; additional lines below it form the long description (which should repeat/incorporate the short description so it reads naturally on its own).
 
@@ -427,7 +494,7 @@ Each entry has a **structural short/long split**: the text on the same line as `
 %
 % Extended description of the function...
 %
-% ## Input Arguments
+% ## :inputs
 %
 % `x` — Input signal.
 % Input signal, specified as a real or complex-valued row vector. The
@@ -442,7 +509,7 @@ Each entry has a **structural short/long split**: the text on the same line as `
 %
 % `opts.Verbose` — Enable verbose output.
 %
-% ## Output Arguments
+% ## :outputs
 %
 % `out` — Interpolated values.
 % Interpolated values, returned as a row vector the same length as
@@ -468,15 +535,15 @@ The renderer resolves argument documentation using the **first available** sourc
 
 | Priority | Source | Short description | Long description |
 |----------|--------|-------------------|-----------------|
-| 1 (highest) | `## Input Arguments` section | Text after `` `arg` — `` on same line | Remaining lines below |
+| 1 (highest) | `## :inputs` section | Text after `` `arg` — `` on same line | Remaining lines below |
 | 2 | Preceding comment block + trailing `%` in `arguments` block | Trailing comment | Preceding block |
 | 3 | Trailing `%` only in `arguments` block | Trailing comment | Trailing comment (serves both) |
 | 4 | `arguments` block, no comments | — | — (type/size/default still auto-rendered) |
 | 5 (lowest) | Function declaration only | — | — (just argument name) |
 
-**Section wins entirely.** If a `## Input Arguments` section exists in the help block, it is the sole source for **all** input argument documentation. Preceding comments and trailing comments in the `arguments` block are treated as ordinary code comments (not rendered as documentation). The same rule applies independently for `## Output Arguments` vs. `arguments (Output)` block documentation.
+**Section wins entirely.** If a `## :inputs` section exists in the help block, it is the sole source for **all** input argument documentation. Preceding comments and trailing comments in the `arguments` block are treated as ordinary code comments (not rendered as documentation). The same rule applies independently for `## :outputs` vs. `arguments (Output)` block documentation.
 
-This means you can freely mix approaches across input vs. output (e.g., arguments-block docs for inputs, `## Output Arguments` in help for outputs). But you cannot mix per-argument within the same category — all input args come from one source, all output args come from one source.
+This means you can freely mix approaches across input vs. output (e.g., arguments-block docs for inputs, `## :outputs` in help for outputs). But you cannot mix per-argument within the same category — all input args come from one source, all output args come from one source.
 
 **Rationale:** Per-argument merging across two locations would be confusing to authors and hard for tooling to surface clearly. The "section wins entirely" rule is simple to explain and implement.
 
@@ -486,16 +553,16 @@ This means you can freely mix approaches across input vs. output (e.g., argument
 
 ## Optional Enhancement Sections
 
-Beyond auto-generated sections, authors can include the following recognized `##` section headings. The renderer applies distinct formatting to each.
+Beyond auto-generated sections, authors can include the following recognized `## :keyword` directives. The renderer applies distinct formatting to each.
 
-### `## Syntax` (explicit full control)
+### `## :syntax` (explicit full control)
 
-When an author includes a `## Syntax` section, it becomes the **sole source** for the compact syntax block and syntax-description pairs. Auto-generation does not run. This gives the author complete control over which calling forms appear and in what order.
+When an author includes a `## :syntax` section, it becomes the **sole source** for the compact syntax block and syntax-description pairs. Auto-generation does not run. This gives the author complete control over which calling forms appear and in what order.
 
-The grammar inside `## Syntax` uses the same calling-form paragraph pattern as the description text: each paragraph starts with a backtick-wrapped calling form, followed by a description. Forms without descriptions are also supported via fenced code blocks.
+The grammar inside `## :syntax` uses the same calling-form paragraph pattern as the description text: each paragraph starts with a backtick-wrapped calling form, followed by a description. Forms without descriptions are also supported via fenced code blocks.
 
 ```matlab
-% ## Syntax
+% ## :syntax
 %
 % `m = weightedmean(x)` computes the arithmetic mean of the elements of
 % `x`, using uniform weights.
@@ -517,22 +584,22 @@ The grammar inside `## Syntax` uses the same calling-form paragraph pattern as t
 
 The renderer extracts calling forms for the compact syntax block and renders the descriptions as syntax-description pairs, matching the MathWorks Description section layout.
 
-When `## Syntax` is present, the freeform description text (before any `##` heading) renders as introductory prose only — calling-form paragraphs in it are not extracted.
+When `## :syntax` is present, the freeform description text (before any `## :keyword` directive) renders as introductory prose only — calling-form paragraphs in it are not extracted.
 
-**When to use `## Syntax` vs. description calling forms:** Both produce the same rendered output. `## Syntax` is useful when the author wants a clean separation between syntax documentation and introductory prose, or when migrating from a legacy help block that mixes calling forms with argument descriptions in the freeform text. Description calling forms are the more natural choice when writing new help text from scratch, since they follow the traditional MATLAB help convention.
+**When to use `## :syntax` vs. description calling forms:** Both produce the same rendered output. `## :syntax` is useful when the author wants a clean separation between syntax documentation and introductory prose, or when migrating from a legacy help block that mixes calling forms with argument descriptions in the freeform text. Description calling forms are the more natural choice when writing new help text from scratch, since they follow the traditional MATLAB help convention.
 
-**Rationale:** Most authors will use calling-form paragraphs in the description text (Priority 2), since it matches how MATLAB help has always been written. `## Syntax` exists as an explicit-control option for authors who prefer structured sections, or when the description text serves a different purpose (e.g., conceptual overview rather than per-syntax explanations).
+**Rationale:** Most authors will use calling-form paragraphs in the description text (Priority 2), since it matches how MATLAB help has always been written. `## :syntax` exists as an explicit-control option for authors who prefer structured sections, or when the description text serves a different purpose (e.g., conceptual overview rather than per-syntax explanations).
 
-*Alternative considered: additive model (writing `## Syntax` supplements auto-generated forms). Rejected because it created confusion — the author couldn't see or control the full set of forms, and couldn't attach descriptions to auto-generated entries.*
+*Alternative considered: additive model (writing `## :syntax` supplements auto-generated forms). Rejected because it created confusion — the author couldn't see or control the full set of forms, and couldn't attach descriptions to auto-generated entries.*
 
-### `## Input Arguments` / `## Output Arguments`
+### `## :inputs` / `## :outputs`
 Long-form argument descriptions (see above).
 
-### `## Examples`
+### `## :examples`
 Code examples. Use fenced code blocks for MATLAB code:
 
 ````markdown
-## Examples
+## :examples
 
 ### Interpolate a sine wave
 
@@ -547,25 +614,25 @@ plot(xi, yi)
 
 The renderer adds syntax highlighting and a Copy button. Multiple `###` subsections become separately titled examples, matching MATLAB's doc page layout.
 
-### `## Tips`
+### `## :tips`
 Guidance, best practices, and performance notes. Renders as a styled prose or bulleted section.
 
-### `## Version History`
+### `## :version-history`
 ```markdown
-## Version History
+## :version-history
 
 **Introduced in R2024b**
 
 **R2025a** — Added `"spline"` option for `Method`.
 ```
 
-### `## Algorithms`
+### `## :algorithms`
 Implementation notes for technically inclined users.
 
-### `## References`
+### `## :references`
 Citations and links to external sources.
 
-### `## More About`
+### `## :more-about`
 Links to conceptual documentation or related topics. Cross-links to other pages in the generated docbook.
 
 ### Callout Blocks
@@ -603,7 +670,7 @@ properties
 end
 ```
 
-Extended property descriptions live in a `## Properties` section in the class help block, keyed by property name, or as preceding comment blocks in the `properties` block. The pattern is intentionally identical to input argument documentation — properties and input arguments are the same concept in this framework.
+Extended property descriptions live in a `## :properties` section in the class help block, keyed by property name, or as preceding comment blocks in the `properties` block. The pattern is intentionally identical to input argument documentation — properties and input arguments are the same concept in this framework.
 
 ### Method Documentation
 Each method carries its own function-level help comment following the same grammar as standalone functions. The class doc page aggregates all public method documentation and generates a Methods section with links to per-method detail sections or pages.
@@ -692,16 +759,16 @@ The generated site mirrors the structure and visual style of MATLAB's official p
 | Callout | `% > [!NOTE] ...` | Help block |
 | Arg short desc | Trailing `% text` on argument line | `arguments` block |
 | Arg long desc (preceding) | `%` block or `%{...%}` before argument line | `arguments` block |
-| Input arg long desc (section) | `` `argName` — ... `` under `## Input Arguments` | Help block |
-| Output arg desc | `` `argName` — ... `` under `## Output Arguments` | Help block |
-| Syntax annotation | `` % `out = f(x, Name=val)` description `` under `## Syntax` | Help block |
+| Input arg long desc (section) | `` `argName` — ... `` under `## :inputs` | Help block |
+| Output arg desc | `` `argName` — ... `` under `## :outputs` | Help block |
+| Syntax annotation | `` % `out = f(x, Name=val)` description `` under `## :syntax` | Help block |
 | See also | `% See also a, b, c` | Help block |
-| Examples | `% ## Examples` + fenced code blocks | Help block |
-| Tips | `% ## Tips` | Help block |
-| Version history | `% ## Version History` | Help block |
-| Algorithms | `% ## Algorithms` | Help block |
-| References | `% ## References` | Help block |
-| More About | `% ## More About` | Help block |
+| Examples | `% ## :examples` + fenced code blocks | Help block |
+| Tips | `% ## :tips` | Help block |
+| Version history | `% ## :version-history` | Help block |
+| Algorithms | `% ## :algorithms` | Help block |
+| References | `% ## :references` | Help block |
+| More About | `% ## :more-about` | Help block |
 
 All elements in the "Help block" column apply equally to both line-comment (`% `) and block-comment (`%{...%}`) forms. The syntax column shows line-comment form; in block-comment form the `% ` prefix is absent.
 
@@ -710,7 +777,7 @@ All elements in the "Help block" column apply equally to both line-comment (`% `
 ## Open Questions
 
 1. **Callout syntax**: finalize the admonition syntax (`> [!NOTE]` vs. a custom prefix)
-2. ~~**`## Syntax` override**: define the exact format for hand-authored syntax entries~~ — **Resolved**: see `## Syntax` (annotate/extend) under Optional Enhancement Sections. The section supports fenced code blocks (forms only) and inline-code paragraphs (forms with descriptions).
+2. ~~**`## :syntax` override**: define the exact format for hand-authored syntax entries~~ — **Resolved**: see `## :syntax` under Optional Enhancement Sections. The directive supports fenced code blocks (forms only) and inline-code paragraphs (forms with descriptions).
 3. **Docbook configuration**: determine minimum configuration surface (site name? include/exclude patterns?)
 4. **`help` stripping behavior**: specify exactly which Markdown constructs are stripped vs. passed through in `help` output
 

--- a/prototype/mdoc_parse.m
+++ b/prototype/mdoc_parse.m
@@ -39,8 +39,8 @@ info.Synopsis = parseSynopsis(helpLines, info.Name);
 [info.Description, info.Sections, info.SeeAlso] = parseHelpBody(helpLines);
 
 %% Extract long-form argument descriptions from sections
-inputArgLong = extractArgDescriptions(info.Sections, "Input Arguments");
-outputArgLong = extractArgDescriptions(info.Sections, "Output Arguments");
+inputArgLong = extractArgDescriptions(info.Sections, ":inputs");
+outputArgLong = extractArgDescriptions(info.Sections, ":outputs");
 
 %% Parse arguments block (if present)
 [parsedArgs, parsedNVArgs] = parseArgumentsBlock(lines, helpEndIdx);
@@ -55,7 +55,7 @@ info.OutputArgs = buildOutputArgs(info.OutputArgNames, outputArgLong);
 %% Classdef-specific parsing
 if info.Type == "classdef"
     % Parse properties, methods, events blocks
-    hasPropsSection = any(arrayfun(@(s) s.Heading == "Properties", info.Sections));
+    hasPropsSection = any(arrayfun(@(s) s.Heading == ":properties", info.Sections));
     info.Properties = parsePropertiesBlocks(lines, hasPropsSection, info.Sections);
     [info.Methods, constructorRange] = parseMethodsBlocks(lines, info.Name);
     info.Events = parseEventsBlocks(lines);
@@ -89,10 +89,10 @@ if info.Type == "classdef"
     info.OutputArgs = struct("Name", {}, "LongDesc", {});
 else
     %% Build syntax entries (three-priority model) — functions only
-    % Priority 1: ## Syntax section is the sole source
+    % Priority 1: ## :syntax directive is the sole source
     syntaxContent = "";
     for k = 1:numel(info.Sections)
-        if info.Sections(k).Heading == "Syntax"
+        if info.Sections(k).Heading == ":syntax"
             syntaxContent = string(info.Sections(k).Content);
             break
         end
@@ -616,7 +616,7 @@ end
 
 function args = mergeArgDescriptions(parsedArgs, longDescMap)
 % Merge long-form descriptions into parsed argument structs
-% Priority: ## Input/Output Arguments section > preceding comments > empty
+% Priority: ## :inputs / ## :outputs directive > preceding comments > empty
 args = parsedArgs;
 for k = 1:numel(args)
     lookupName = char(args(k).Name);
@@ -688,7 +688,7 @@ end
 end
 
 function entries = parseSyntaxSection(content, funcName)
-% Parse a ## Syntax section for calling forms and descriptions.
+% Parse a ## :syntax section for calling forms and descriptions.
 % Handles fenced code blocks (forms only) and calling-form paragraphs
 % (forms with descriptions). funcName is used only for validation of
 % calling-form paragraphs; fenced code block lines are accepted as-is.
@@ -843,7 +843,7 @@ props = struct("Name", {}, "Size", {}, "Class", {}, "Default", {}, ...
     "ShortDesc", {}, "LongDesc", {}, "Group", {}, "ReadOnly", {}, ...
     "Dependent", {}, "Constant", {}, "Abstract", {});
 
-% If ## Properties section exists, use it (correctly separates short/long)
+% If ## :properties directive exists, use it (correctly separates short/long)
 if hasPropsSection
     props = parsePropertiesFromSection(sections);
 end
@@ -853,7 +853,7 @@ blockProps = parsePropertiesBlocksRaw(lines);
 
 if ~isempty(blockProps)
     if isempty(props)
-        % No ## Properties section — use block-parsed properties directly
+        % No ## :properties directive — use block-parsed properties directly
         props = blockProps;
     else
         % Merge block metadata (Size, Class, Default, flags) into section-defined props.
@@ -986,14 +986,14 @@ end
 end
 
 function props = parsePropertiesFromSection(sections)
-% Build property list from ## Properties section content.
+% Build property list from ## :properties section content.
 % Each property is listed as `name` — short description, followed by
 % optional continuation lines that form the long description.
 props = struct("Name", {}, "Size", {}, "Class", {}, "Default", {}, ...
     "ShortDesc", {}, "LongDesc", {}, "Group", {}, "ReadOnly", {}, ...
     "Dependent", {}, "Constant", {}, "Abstract", {});
 for s = 1:numel(sections)
-    if sections(s).Heading == "Properties"
+    if sections(s).Heading == ":properties"
         contentLines = splitlines(string(sections(s).Content));
         currentName = "";
         currentShort = "";
@@ -1241,7 +1241,7 @@ ctorInfo.Synopsis = parseSynopsis(helpLines, className);
 [ctorInfo.Description, ctorInfo.Sections, ~] = parseHelpBody(helpLines);
 
 % Extract argument descriptions from help sections
-inputArgLong = extractArgDescriptions(ctorInfo.Sections, "Input Arguments");
+inputArgLong = extractArgDescriptions(ctorInfo.Sections, ":inputs");
 
 % Parse arguments block within constructor
 [parsedArgs, parsedNVArgs] = parseArgumentsBlock(ctorLines, helpEndIdx);
@@ -1251,7 +1251,7 @@ ctorInfo.NameValueArgs = mergeArgDescriptions(parsedNVArgs, inputArgLong);
 % Build syntax entries
 syntaxContent = "";
 for s = 1:numel(ctorInfo.Sections)
-    if ctorInfo.Sections(s).Heading == "Syntax"
+    if ctorInfo.Sections(s).Heading == ":syntax"
         syntaxContent = string(ctorInfo.Sections(s).Content);
         break
     end
@@ -1299,8 +1299,8 @@ mInfo.Synopsis = parseSynopsis(helpLines, methodName);
 [mInfo.Description, mInfo.Sections, mInfo.SeeAlso] = parseHelpBody(helpLines);
 
 % Extract argument descriptions from help sections
-inputArgLong = extractArgDescriptions(mInfo.Sections, "Input Arguments");
-outputArgLong = extractArgDescriptions(mInfo.Sections, "Output Arguments");
+inputArgLong = extractArgDescriptions(mInfo.Sections, ":inputs");
+outputArgLong = extractArgDescriptions(mInfo.Sections, ":outputs");
 
 % Parse arguments block
 [parsedArgs, parsedNVArgs] = parseArgumentsBlock(mLines, helpEndIdx);
@@ -1311,7 +1311,7 @@ mInfo.OutputArgs = buildOutputArgs(outArgNames, outputArgLong);
 % Build syntax entries (same three-priority model as functions)
 syntaxContent = "";
 for s = 1:numel(mInfo.Sections)
-    if mInfo.Sections(s).Heading == "Syntax"
+    if mInfo.Sections(s).Heading == ":syntax"
         syntaxContent = string(mInfo.Sections(s).Content);
         break
     end

--- a/prototype/mdoc_render.m
+++ b/prototype/mdoc_render.m
@@ -91,7 +91,7 @@ else
 end
 
 % Examples (before Input Arguments, matching MathWorks order)
-examplesContent = findSectionContent(info.Sections, "Examples");
+examplesContent = findSectionContent(info.Sections, ":examples");
 if examplesContent ~= ""
     parts{end+1} = renderExamples(examplesContent);
 end
@@ -191,7 +191,7 @@ if isfield(info, 'Events') && ~isempty(info.Events)
 end
 
 % Examples and remaining sections
-examplesContent = findSectionContent(info.Sections, "Examples");
+examplesContent = findSectionContent(info.Sections, ":examples");
 if examplesContent ~= ""
     parts{end+1} = renderExamples(examplesContent);
 end
@@ -201,13 +201,17 @@ end
 
 function parts = renderRemainingSections(info)
 % Render Tips, Algorithms, Version History, etc. and See Also.
+% Each entry is {pragma key, display label} — pragma keys match what
+% parseHelpBody stores from ## :keyword directives.
 parts = {};
-sectionOrder = ["Tips", "Algorithms", "Version History", ...
-    "References", "More About"];
-for s = sectionOrder
-    content = findSectionContent(info.Sections, s);
+sectionKeys   = [":tips",       ":algorithms", ":version-history", ...
+                 ":references", ":more-about"];
+sectionLabels = ["Tips",        "Algorithms",  "Version History",  ...
+                 "References",  "More About"];
+for i = 1:numel(sectionKeys)
+    content = findSectionContent(info.Sections, sectionKeys(i));
     if content ~= ""
-        parts{end+1} = sprintf('<h2>%s</h2>', esc(s)); %#ok<AGROW>
+        parts{end+1} = sprintf('<h2>%s</h2>', esc(sectionLabels(i))); %#ok<AGROW>
         parts{end+1} = char(blockMd(content)); %#ok<AGROW>
     end
 end


### PR DESCRIPTION
Replaces recognized section headings like '## Input Arguments' and '## Examples' with '## :inputs' and '## :examples' across the spec, sample files, and prototype.

Rationale: Magic English strings are fragile (easy to mistype), locale-specific, and don't generalize. The :keyword prefix is unambiguous, locale-independent, and extensible — the same prefix will serve future block-level directives (e.g., :embed myFunc) for embedding reference content in standalone pages, consistent with mkdocstrings-style directive vocabulary.

Changes:
- doc-framework-spec.md: add 'Pragma Syntax' section with full rationale
  and alternatives considered; update all references throughout
- GettingStarted.md: update all code examples and prose
- class-support-design.md: update all section references
- SampleFiles/**/*.m: bulk update all sample files
- SampleFiles/**/readme.md: update description text
- prototype/mdoc_parse.m: update section key lookups (':inputs', ':outputs',
  ':syntax', ':properties' etc.) — display labels unchanged
- prototype/mdoc_render.m: update findSectionContent keys; split renderRemainingSections into separate key/label arrays

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>